### PR TITLE
simplify serialized output have to less default noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2021-04-21
+### Changed
+- Instead of the serialization library writing all default values in the sarif,
+it now relies on the consumer of the sarif to respect the behavior in the sarif
+specification to assume the default value for an absent property.

--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ Public Getters & Setters are provided.
 
 #### Jackson
 
-Classes are decorated with `@JsonInclude(JsonInclude.Include.NON_NULL)` and `@JsonPropertyOrder`
+Classes are decorated with `@JsonInclude(JsonInclude.Include.NON_DEFAULT)` and `@JsonPropertyOrder`
 which dictates the order from the JSON schema.
 
 ```java
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 // ...
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "text",
     "markdown",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It uses Jackson for serialising/deserialing from JSON.
 <dependency>
   <groupId>com.contrastsecurity</groupId>
   <artifactId>java-sarif</artifactId>
-  <version>1.0</version>
+  <version>2.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.contrastsecurity</groupId>
   <artifactId>java-sarif</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
 
   <organization>
     <name>Contrast Security</name>
@@ -70,6 +70,7 @@
     <versions.nexus-staging-maven-plugin>1.6.8</versions.nexus-staging-maven-plugin>
     <versions.junit-jupiter>5.7.1</versions.junit-jupiter>
     <versions.assertj>3.18.1</versions.assertj>
+    <versions.surefire>2.22.2</versions.surefire>
   </properties>
 
   <dependencies>
@@ -224,6 +225,11 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${versions.surefire}</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,8 @@
     <versions.maven-javadoc-plugin>3.0.0</versions.maven-javadoc-plugin>
     <versions.maven-gpg-plugin>1.6</versions.maven-gpg-plugin>
     <versions.nexus-staging-maven-plugin>1.6.8</versions.nexus-staging-maven-plugin>
+    <versions.junit-jupiter>5.7.1</versions.junit-jupiter>
+    <versions.assertj>3.18.1</versions.assertj>
   </properties>
 
   <dependencies>
@@ -85,6 +87,30 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${versions.jackson-databind}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${versions.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${versions.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${versions.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${versions.assertj}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -187,6 +213,8 @@
           <targetPackage>com.contrastsecurity.sarif</targetPackage>
           <generateBuilders>true</generateBuilders>
           <outputDirectory>${project.build.sourceDirectory}</outputDirectory>
+          <inclusionLevel>NON_DEFAULT</inclusionLevel>
+          <initializeCollections>false</initializeCollections>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/com/contrastsecurity/sarif/Address.java
+++ b/src/main/java/com/contrastsecurity/sarif/Address.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "absoluteAddress",
     "relativeAddress",

--- a/src/main/java/com/contrastsecurity/sarif/Artifact.java
+++ b/src/main/java/com/contrastsecurity/sarif/Artifact.java
@@ -2,7 +2,6 @@
 package com.contrastsecurity.sarif;
 
 import java.util.Date;
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -15,7 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * A single artifact. In some cases, this artifact might be nested within another artifact.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "description",
     "location",
@@ -75,7 +74,7 @@ public class Artifact {
     @JsonProperty("roles")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("The role or roles played by the artifact in the analysis.")
-    private Set<Role> roles = new LinkedHashSet<Role>();
+    private Set<Role> roles = null;
     /**
      * The MIME type (RFC 2045) of the artifact.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ArtifactChange.java
+++ b/src/main/java/com/contrastsecurity/sarif/ArtifactChange.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A change to a single artifact.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "artifactLocation",
     "replacements",
@@ -36,7 +35,7 @@ public class ArtifactChange {
      */
     @JsonProperty("replacements")
     @JsonPropertyDescription("An array of replacement objects, each of which represents the replacement of a single region in a single artifact specified by 'artifactLocation'.")
-    private List<Replacement> replacements = new ArrayList<Replacement>();
+    private List<Replacement> replacements = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ArtifactContent.java
+++ b/src/main/java/com/contrastsecurity/sarif/ArtifactContent.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Represents the contents of an artifact.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "text",
     "binary",

--- a/src/main/java/com/contrastsecurity/sarif/ArtifactLocation.java
+++ b/src/main/java/com/contrastsecurity/sarif/ArtifactLocation.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Specifies the location of an artifact.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "uri",
     "uriBaseId",

--- a/src/main/java/com/contrastsecurity/sarif/Attachment.java
+++ b/src/main/java/com/contrastsecurity/sarif/Attachment.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,7 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * An artifact relevant to a result.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "description",
     "artifactLocation",
@@ -46,7 +45,7 @@ public class Attachment {
     @JsonProperty("regions")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of regions of interest within the attachment.")
-    private Set<Region> regions = new LinkedHashSet<Region>();
+    private Set<Region> regions = null;
     /**
      * An array of rectangles specifying areas of interest within the image.
      * 
@@ -54,7 +53,7 @@ public class Attachment {
     @JsonProperty("rectangles")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of rectangles specifying areas of interest within the image.")
-    private Set<Rectangle> rectangles = new LinkedHashSet<Rectangle>();
+    private Set<Rectangle> rectangles = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/CodeFlow.java
+++ b/src/main/java/com/contrastsecurity/sarif/CodeFlow.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A set of threadFlows which together describe a pattern of code execution relevant to detecting a result.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "message",
     "threadFlows",
@@ -35,7 +34,7 @@ public class CodeFlow {
      */
     @JsonProperty("threadFlows")
     @JsonPropertyDescription("An array of one or more unique threadFlow objects, each of which describes the progress of a program through a thread of execution.")
-    private List<ThreadFlow> threadFlows = new ArrayList<ThreadFlow>();
+    private List<ThreadFlow> threadFlows = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ConfigurationOverride.java
+++ b/src/main/java/com/contrastsecurity/sarif/ConfigurationOverride.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Information about how a specific rule or notification was reconfigured at runtime.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "configuration",
     "descriptor",

--- a/src/main/java/com/contrastsecurity/sarif/Conversion.java
+++ b/src/main/java/com/contrastsecurity/sarif/Conversion.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,7 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "tool",
     "invocation",
@@ -45,7 +44,7 @@ public class Conversion {
     @JsonProperty("analysisToolLogFiles")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("The locations of the analysis tool's per-run log files.")
-    private Set<ArtifactLocation> analysisToolLogFiles = new LinkedHashSet<ArtifactLocation>();
+    private Set<ArtifactLocation> analysisToolLogFiles = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/Edge.java
+++ b/src/main/java/com/contrastsecurity/sarif/Edge.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Represents a directed edge in a graph.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "id",
     "label",

--- a/src/main/java/com/contrastsecurity/sarif/EdgeTraversal.java
+++ b/src/main/java/com/contrastsecurity/sarif/EdgeTraversal.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Represents the traversal of a single edge during a graph traversal.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "edgeId",
     "message",

--- a/src/main/java/com/contrastsecurity/sarif/EnvironmentVariables.java
+++ b/src/main/java/com/contrastsecurity/sarif/EnvironmentVariables.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * The environment variables associated with the analysis tool process, expressed as key/value pairs.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/Exception.java
+++ b/src/main/java/com/contrastsecurity/sarif/Exception.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Describes a runtime exception encountered during the execution of an analysis tool.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "kind",
     "message",
@@ -50,7 +49,7 @@ public class Exception {
      */
     @JsonProperty("innerExceptions")
     @JsonPropertyDescription("An array of exception objects each of which is considered a cause of this exception.")
-    private List<Exception> innerExceptions = new ArrayList<Exception>();
+    private List<Exception> innerExceptions = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ExternalProperties.java
+++ b/src/main/java/com/contrastsecurity/sarif/ExternalProperties.java
@@ -2,9 +2,7 @@
 package com.contrastsecurity.sarif;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,7 +19,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * The top-level element of an external property file.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "schema",
     "version",
@@ -89,7 +87,7 @@ public class ExternalProperties {
     @JsonProperty("graphs")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of graph objects that will be merged with a separate run.")
-    private Set<Graph> graphs = new LinkedHashSet<Graph>();
+    private Set<Graph> graphs = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 
@@ -104,14 +102,14 @@ public class ExternalProperties {
     @JsonProperty("artifacts")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of artifact objects that will be merged with a separate run.")
-    private Set<Artifact> artifacts = new LinkedHashSet<Artifact>();
+    private Set<Artifact> artifacts = null;
     /**
      * Describes the invocation of the analysis tool that will be merged with a separate run.
      * 
      */
     @JsonProperty("invocations")
     @JsonPropertyDescription("Describes the invocation of the analysis tool that will be merged with a separate run.")
-    private List<Invocation> invocations = new ArrayList<Invocation>();
+    private List<Invocation> invocations = null;
     /**
      * An array of logical locations such as namespaces, types or functions that will be merged with a separate run.
      * 
@@ -119,7 +117,7 @@ public class ExternalProperties {
     @JsonProperty("logicalLocations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of logical locations such as namespaces, types or functions that will be merged with a separate run.")
-    private Set<LogicalLocation> logicalLocations = new LinkedHashSet<LogicalLocation>();
+    private Set<LogicalLocation> logicalLocations = null;
     /**
      * An array of threadFlowLocation objects that will be merged with a separate run.
      * 
@@ -127,14 +125,14 @@ public class ExternalProperties {
     @JsonProperty("threadFlowLocations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of threadFlowLocation objects that will be merged with a separate run.")
-    private Set<ThreadFlowLocation> threadFlowLocations = new LinkedHashSet<ThreadFlowLocation>();
+    private Set<ThreadFlowLocation> threadFlowLocations = null;
     /**
      * An array of result objects that will be merged with a separate run.
      * 
      */
     @JsonProperty("results")
     @JsonPropertyDescription("An array of result objects that will be merged with a separate run.")
-    private List<Result> results = new ArrayList<Result>();
+    private List<Result> results = null;
     /**
      * Tool taxonomies that will be merged with a separate run.
      * 
@@ -142,7 +140,7 @@ public class ExternalProperties {
     @JsonProperty("taxonomies")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Tool taxonomies that will be merged with a separate run.")
-    private Set<ToolComponent> taxonomies = new LinkedHashSet<ToolComponent>();
+    private Set<ToolComponent> taxonomies = null;
     /**
      * A component, such as a plug-in or the driver, of the analysis tool that was run.
      * 
@@ -157,7 +155,7 @@ public class ExternalProperties {
     @JsonProperty("extensions")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Tool extensions that will be merged with a separate run.")
-    private Set<ToolComponent> extensions = new LinkedHashSet<ToolComponent>();
+    private Set<ToolComponent> extensions = null;
     /**
      * Tool policies that will be merged with a separate run.
      * 
@@ -165,7 +163,7 @@ public class ExternalProperties {
     @JsonProperty("policies")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Tool policies that will be merged with a separate run.")
-    private Set<ToolComponent> policies = new LinkedHashSet<ToolComponent>();
+    private Set<ToolComponent> policies = null;
     /**
      * Tool translations that will be merged with a separate run.
      * 
@@ -173,14 +171,14 @@ public class ExternalProperties {
     @JsonProperty("translations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Tool translations that will be merged with a separate run.")
-    private Set<ToolComponent> translations = new LinkedHashSet<ToolComponent>();
+    private Set<ToolComponent> translations = null;
     /**
      * Addresses that will be merged with a separate run.
      * 
      */
     @JsonProperty("addresses")
     @JsonPropertyDescription("Addresses that will be merged with a separate run.")
-    private List<Address> addresses = new ArrayList<Address>();
+    private List<Address> addresses = null;
     /**
      * Requests that will be merged with a separate run.
      * 
@@ -188,7 +186,7 @@ public class ExternalProperties {
     @JsonProperty("webRequests")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Requests that will be merged with a separate run.")
-    private Set<WebRequest> webRequests = new LinkedHashSet<WebRequest>();
+    private Set<WebRequest> webRequests = null;
     /**
      * Responses that will be merged with a separate run.
      * 
@@ -196,7 +194,7 @@ public class ExternalProperties {
     @JsonProperty("webResponses")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Responses that will be merged with a separate run.")
-    private Set<WebResponse> webResponses = new LinkedHashSet<WebResponse>();
+    private Set<WebResponse> webResponses = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ExternalPropertyFileReference.java
+++ b/src/main/java/com/contrastsecurity/sarif/ExternalPropertyFileReference.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "location",
     "guid",

--- a/src/main/java/com/contrastsecurity/sarif/ExternalPropertyFileReferences.java
+++ b/src/main/java/com/contrastsecurity/sarif/ExternalPropertyFileReferences.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,7 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * References to external property files that should be inlined with the content of a root log file.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "conversion",
     "graphs",
@@ -50,7 +49,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("graphs")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing a run.graphs object to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> graphs = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> graphs = null;
     /**
      * Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.
      * 
@@ -65,7 +64,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("artifacts")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.artifacts arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> artifacts = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> artifacts = null;
     /**
      * An array of external property files containing run.invocations arrays to be merged with the root log file.
      * 
@@ -73,7 +72,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("invocations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.invocations arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> invocations = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> invocations = null;
     /**
      * An array of external property files containing run.logicalLocations arrays to be merged with the root log file.
      * 
@@ -81,7 +80,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("logicalLocations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.logicalLocations arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> logicalLocations = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> logicalLocations = null;
     /**
      * An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.
      * 
@@ -89,7 +88,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("threadFlowLocations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> threadFlowLocations = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> threadFlowLocations = null;
     /**
      * An array of external property files containing run.results arrays to be merged with the root log file.
      * 
@@ -97,7 +96,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("results")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.results arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> results = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> results = null;
     /**
      * An array of external property files containing run.taxonomies arrays to be merged with the root log file.
      * 
@@ -105,7 +104,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("taxonomies")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.taxonomies arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> taxonomies = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> taxonomies = null;
     /**
      * An array of external property files containing run.addresses arrays to be merged with the root log file.
      * 
@@ -113,7 +112,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("addresses")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.addresses arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> addresses = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> addresses = null;
     /**
      * Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.
      * 
@@ -128,7 +127,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("extensions")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.extensions arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> extensions = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> extensions = null;
     /**
      * An array of external property files containing run.policies arrays to be merged with the root log file.
      * 
@@ -136,7 +135,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("policies")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.policies arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> policies = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> policies = null;
     /**
      * An array of external property files containing run.translations arrays to be merged with the root log file.
      * 
@@ -144,7 +143,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("translations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.translations arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> translations = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> translations = null;
     /**
      * An array of external property files containing run.requests arrays to be merged with the root log file.
      * 
@@ -152,7 +151,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("webRequests")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.requests arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> webRequests = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> webRequests = null;
     /**
      * An array of external property files containing run.responses arrays to be merged with the root log file.
      * 
@@ -160,7 +159,7 @@ public class ExternalPropertyFileReferences {
     @JsonProperty("webResponses")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of external property files containing run.responses arrays to be merged with the root log file.")
-    private Set<ExternalPropertyFileReference> webResponses = new LinkedHashSet<ExternalPropertyFileReference>();
+    private Set<ExternalPropertyFileReference> webResponses = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/FinalState.java
+++ b/src/main/java/com/contrastsecurity/sarif/FinalState.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * The values of relevant expressions after the edge has been traversed.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/Fingerprints.java
+++ b/src/main/java/com/contrastsecurity/sarif/Fingerprints.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A set of strings each of which individually defines a stable, unique identity for the result.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/Fix.java
+++ b/src/main/java/com/contrastsecurity/sarif/Fix.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,7 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * A proposed fix for the problem represented by a result object. A fix specifies a set of artifacts to modify. For each artifact, it specifies a set of bytes to remove, and provides a set of new bytes to replace them.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "description",
     "artifactChanges",
@@ -37,7 +36,7 @@ public class Fix {
     @JsonProperty("artifactChanges")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("One or more artifact changes that comprise a fix for a result.")
-    private Set<ArtifactChange> artifactChanges = new LinkedHashSet<ArtifactChange>();
+    private Set<ArtifactChange> artifactChanges = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/GlobalMessageStrings.java
+++ b/src/main/java/com/contrastsecurity/sarif/GlobalMessageStrings.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A dictionary, each of whose keys is a resource identifier and each of whose values is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/Graph.java
+++ b/src/main/java/com/contrastsecurity/sarif/Graph.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,7 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * A network of nodes and directed edges that describes some aspect of the structure of the code (for example, a call graph).
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "description",
     "nodes",
@@ -37,7 +36,7 @@ public class Graph {
     @JsonProperty("nodes")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of node objects representing the nodes of the graph.")
-    private Set<Node> nodes = new LinkedHashSet<Node>();
+    private Set<Node> nodes = null;
     /**
      * An array of edge objects representing the edges of the graph.
      * 
@@ -45,7 +44,7 @@ public class Graph {
     @JsonProperty("edges")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of edge objects representing the edges of the graph.")
-    private Set<Edge> edges = new LinkedHashSet<Edge>();
+    private Set<Edge> edges = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/GraphTraversal.java
+++ b/src/main/java/com/contrastsecurity/sarif/GraphTraversal.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Represents a path through a graph.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "runGraphIndex",
     "resultGraphIndex",
@@ -66,7 +65,7 @@ public class GraphTraversal {
      */
     @JsonProperty("edgeTraversals")
     @JsonPropertyDescription("The sequences of edges traversed by this graph traversal.")
-    private List<EdgeTraversal> edgeTraversals = new ArrayList<EdgeTraversal>();
+    private List<EdgeTraversal> edgeTraversals = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/Hashes.java
+++ b/src/main/java/com/contrastsecurity/sarif/Hashes.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A dictionary, each of whose keys is the name of a hash function and each of whose values is the hashed value of the artifact produced by the specified hash function.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/Headers.java
+++ b/src/main/java/com/contrastsecurity/sarif/Headers.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * The request headers.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/Headers__1.java
+++ b/src/main/java/com/contrastsecurity/sarif/Headers__1.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * The response headers.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/ImmutableState.java
+++ b/src/main/java/com/contrastsecurity/sarif/ImmutableState.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Values of relevant expressions at the start of the thread flow that remain constant.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/ImmutableState__1.java
+++ b/src/main/java/com/contrastsecurity/sarif/ImmutableState__1.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Values of relevant expressions at the start of the graph traversal that remain constant for the graph traversal.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/InitialState.java
+++ b/src/main/java/com/contrastsecurity/sarif/InitialState.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Values of relevant expressions at the start of the thread flow that may change during thread flow execution.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/InitialState__1.java
+++ b/src/main/java/com/contrastsecurity/sarif/InitialState__1.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Values of relevant expressions at the start of the graph traversal that may change during graph traversal.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/Invocation.java
+++ b/src/main/java/com/contrastsecurity/sarif/Invocation.java
@@ -1,9 +1,7 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -17,7 +15,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * The runtime environment of the analysis tool run.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "commandLine",
     "arguments",
@@ -61,7 +59,7 @@ public class Invocation {
      */
     @JsonProperty("arguments")
     @JsonPropertyDescription("An array of strings, containing in order the command line arguments passed to the tool from the operating system.")
-    private List<String> arguments = new ArrayList<String>();
+    private List<String> arguments = null;
     /**
      * The locations of any response files specified on the tool's command line.
      * 
@@ -69,7 +67,7 @@ public class Invocation {
     @JsonProperty("responseFiles")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("The locations of any response files specified on the tool's command line.")
-    private Set<ArtifactLocation> responseFiles = new LinkedHashSet<ArtifactLocation>();
+    private Set<ArtifactLocation> responseFiles = null;
     /**
      * The Coordinated Universal Time (UTC) date and time at which the invocation started. See "Date/time properties" in the SARIF spec for the required format.
      * 
@@ -98,7 +96,7 @@ public class Invocation {
     @JsonProperty("ruleConfigurationOverrides")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of configurationOverride objects that describe rules related runtime overrides.")
-    private Set<ConfigurationOverride> ruleConfigurationOverrides = new LinkedHashSet<ConfigurationOverride>();
+    private Set<ConfigurationOverride> ruleConfigurationOverrides = null;
     /**
      * An array of configurationOverride objects that describe notifications related runtime overrides.
      * 
@@ -106,21 +104,21 @@ public class Invocation {
     @JsonProperty("notificationConfigurationOverrides")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of configurationOverride objects that describe notifications related runtime overrides.")
-    private Set<ConfigurationOverride> notificationConfigurationOverrides = new LinkedHashSet<ConfigurationOverride>();
+    private Set<ConfigurationOverride> notificationConfigurationOverrides = null;
     /**
      * A list of runtime conditions detected by the tool during the analysis.
      * 
      */
     @JsonProperty("toolExecutionNotifications")
     @JsonPropertyDescription("A list of runtime conditions detected by the tool during the analysis.")
-    private List<Notification> toolExecutionNotifications = new ArrayList<Notification>();
+    private List<Notification> toolExecutionNotifications = null;
     /**
      * A list of conditions detected by the tool that are relevant to the tool's configuration.
      * 
      */
     @JsonProperty("toolConfigurationNotifications")
     @JsonPropertyDescription("A list of conditions detected by the tool that are relevant to the tool's configuration.")
-    private List<Notification> toolConfigurationNotifications = new ArrayList<Notification>();
+    private List<Notification> toolConfigurationNotifications = null;
     /**
      * The reason for the process exit.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/Location.java
+++ b/src/main/java/com/contrastsecurity/sarif/Location.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,7 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * A location within a programming artifact.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "id",
     "physicalLocation",
@@ -47,7 +46,7 @@ public class Location {
     @JsonProperty("logicalLocations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("The logical locations associated with the result.")
-    private Set<LogicalLocation> logicalLocations = new LinkedHashSet<LogicalLocation>();
+    private Set<LogicalLocation> logicalLocations = null;
     /**
      * Encapsulates a message intended to be read by the end user.
      * 
@@ -62,7 +61,7 @@ public class Location {
     @JsonProperty("annotations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("A set of regions relevant to the location.")
-    private Set<Region> annotations = new LinkedHashSet<Region>();
+    private Set<Region> annotations = null;
     /**
      * An array of objects that describe relationships between this location and others.
      * 
@@ -70,7 +69,7 @@ public class Location {
     @JsonProperty("relationships")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of objects that describe relationships between this location and others.")
-    private Set<LocationRelationship> relationships = new LinkedHashSet<LocationRelationship>();
+    private Set<LocationRelationship> relationships = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/LocationRelationship.java
+++ b/src/main/java/com/contrastsecurity/sarif/LocationRelationship.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Information about the relation of one location to another.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "target",
     "kinds",

--- a/src/main/java/com/contrastsecurity/sarif/LogicalLocation.java
+++ b/src/main/java/com/contrastsecurity/sarif/LogicalLocation.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A logical location of a construct that produced a result.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "name",
     "index",

--- a/src/main/java/com/contrastsecurity/sarif/Message.java
+++ b/src/main/java/com/contrastsecurity/sarif/Message.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Encapsulates a message intended to be read by the end user.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "text",
     "markdown",
@@ -50,7 +49,7 @@ public class Message {
      */
     @JsonProperty("arguments")
     @JsonPropertyDescription("An array of strings to substitute into the message string.")
-    private List<String> arguments = new ArrayList<String>();
+    private List<String> arguments = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/MessageStrings.java
+++ b/src/main/java/com/contrastsecurity/sarif/MessageStrings.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A set of name/value pairs with arbitrary names. Each value is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/MultiformatMessageString.java
+++ b/src/main/java/com/contrastsecurity/sarif/MultiformatMessageString.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A message string or message format string rendered in multiple formats.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "text",
     "markdown",

--- a/src/main/java/com/contrastsecurity/sarif/Node.java
+++ b/src/main/java/com/contrastsecurity/sarif/Node.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,7 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Represents a node in a graph.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "id",
     "label",
@@ -53,7 +52,7 @@ public class Node {
     @JsonProperty("children")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Array of child nodes.")
-    private Set<Node> children = new LinkedHashSet<Node>();
+    private Set<Node> children = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/Notification.java
+++ b/src/main/java/com/contrastsecurity/sarif/Notification.java
@@ -3,7 +3,6 @@ package com.contrastsecurity.sarif;
 
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +18,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Describes a condition relevant to the tool itself, as opposed to being relevant to a target being analyzed by the tool.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "locations",
     "message",
@@ -40,7 +39,7 @@ public class Notification {
     @JsonProperty("locations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("The locations relevant to this notification.")
-    private Set<Location> locations = new LinkedHashSet<Location>();
+    private Set<Location> locations = null;
     /**
      * Encapsulates a message intended to be read by the end user.
      * (Required)

--- a/src/main/java/com/contrastsecurity/sarif/OriginalUriBaseIds.java
+++ b/src/main/java/com/contrastsecurity/sarif/OriginalUriBaseIds.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * The artifact location specified by each uriBaseId symbol on the machine where the tool originally ran.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/Parameters.java
+++ b/src/main/java/com/contrastsecurity/sarif/Parameters.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * The request parameters.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/PartialFingerprints.java
+++ b/src/main/java/com/contrastsecurity/sarif/PartialFingerprints.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A set of strings that contribute to the stable, unique identity of the result.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/PhysicalLocation.java
+++ b/src/main/java/com/contrastsecurity/sarif/PhysicalLocation.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "address",
     "artifactLocation",

--- a/src/main/java/com/contrastsecurity/sarif/PropertyBag.java
+++ b/src/main/java/com/contrastsecurity/sarif/PropertyBag.java
@@ -2,7 +2,6 @@
 package com.contrastsecurity.sarif;
 
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -19,7 +18,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Key/value pairs that provide additional information about the object.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "tags"
 })
@@ -32,7 +31,7 @@ public class PropertyBag {
     @JsonProperty("tags")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("A set of distinct strings that provide additional information.")
-    private Set<String> tags = new LinkedHashSet<String>();
+    private Set<String> tags = null;
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 

--- a/src/main/java/com/contrastsecurity/sarif/Rectangle.java
+++ b/src/main/java/com/contrastsecurity/sarif/Rectangle.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * An area within an image.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "top",
     "left",

--- a/src/main/java/com/contrastsecurity/sarif/Region.java
+++ b/src/main/java/com/contrastsecurity/sarif/Region.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A region within an artifact where a result was detected.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "startLine",
     "startColumn",

--- a/src/main/java/com/contrastsecurity/sarif/Replacement.java
+++ b/src/main/java/com/contrastsecurity/sarif/Replacement.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * The replacement of a single region of an artifact.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "deletedRegion",
     "insertedContent",

--- a/src/main/java/com/contrastsecurity/sarif/ReportingConfiguration.java
+++ b/src/main/java/com/contrastsecurity/sarif/ReportingConfiguration.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Information about a rule or notification that can be configured at runtime.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "enabled",
     "level",

--- a/src/main/java/com/contrastsecurity/sarif/ReportingDescriptor.java
+++ b/src/main/java/com/contrastsecurity/sarif/ReportingDescriptor.java
@@ -2,7 +2,6 @@
 package com.contrastsecurity.sarif;
 
 import java.net.URI;
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -15,7 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "id",
     "deprecatedIds",
@@ -49,7 +48,7 @@ public class ReportingDescriptor {
     @JsonProperty("deprecatedIds")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of stable, opaque identifiers by which this report was known in some previous version of the analysis tool.")
-    private Set<String> deprecatedIds = new LinkedHashSet<String>();
+    private Set<String> deprecatedIds = null;
     /**
      * A unique identifer for the reporting descriptor in the form of a GUID.
      * 
@@ -64,7 +63,7 @@ public class ReportingDescriptor {
     @JsonProperty("deprecatedGuids")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of unique identifies in the form of a GUID by which this report was known in some previous version of the analysis tool.")
-    private Set<String> deprecatedGuids = new LinkedHashSet<String>();
+    private Set<String> deprecatedGuids = null;
     /**
      * A report identifier that is understandable to an end user.
      * 
@@ -79,7 +78,7 @@ public class ReportingDescriptor {
     @JsonProperty("deprecatedNames")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of readable identifiers by which this report was known in some previous version of the analysis tool.")
-    private Set<String> deprecatedNames = new LinkedHashSet<String>();
+    private Set<String> deprecatedNames = null;
     /**
      * A message string or message format string rendered in multiple formats.
      * 
@@ -129,7 +128,7 @@ public class ReportingDescriptor {
     @JsonProperty("relationships")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of objects that describe relationships between this reporting descriptor and others.")
-    private Set<ReportingDescriptorRelationship> relationships = new LinkedHashSet<ReportingDescriptorRelationship>();
+    private Set<ReportingDescriptorRelationship> relationships = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ReportingDescriptorReference.java
+++ b/src/main/java/com/contrastsecurity/sarif/ReportingDescriptorReference.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Information about how to locate a relevant reporting descriptor.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "id",
     "index",

--- a/src/main/java/com/contrastsecurity/sarif/ReportingDescriptorRelationship.java
+++ b/src/main/java/com/contrastsecurity/sarif/ReportingDescriptorRelationship.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Information about the relation of one reporting descriptor to another.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "target",
     "kinds",

--- a/src/main/java/com/contrastsecurity/sarif/Result.java
+++ b/src/main/java/com/contrastsecurity/sarif/Result.java
@@ -2,9 +2,7 @@
 package com.contrastsecurity.sarif;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,7 +19,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * A result produced by an analysis tool.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "ruleId",
     "ruleIndex",
@@ -112,7 +110,7 @@ public class Result {
      */
     @JsonProperty("locations")
     @JsonPropertyDescription("The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.")
-    private List<Location> locations = new ArrayList<Location>();
+    private List<Location> locations = null;
     /**
      * A stable, unique identifer for the result in the form of a GUID.
      * 
@@ -155,14 +153,14 @@ public class Result {
     @JsonProperty("stacks")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of 'stack' objects relevant to the result.")
-    private Set<Stack> stacks = new LinkedHashSet<Stack>();
+    private Set<Stack> stacks = null;
     /**
      * An array of 'codeFlow' objects relevant to the result.
      * 
      */
     @JsonProperty("codeFlows")
     @JsonPropertyDescription("An array of 'codeFlow' objects relevant to the result.")
-    private List<CodeFlow> codeFlows = new ArrayList<CodeFlow>();
+    private List<CodeFlow> codeFlows = null;
     /**
      * An array of zero or more unique graph objects associated with the result.
      * 
@@ -170,7 +168,7 @@ public class Result {
     @JsonProperty("graphs")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of zero or more unique graph objects associated with the result.")
-    private Set<Graph> graphs = new LinkedHashSet<Graph>();
+    private Set<Graph> graphs = null;
     /**
      * An array of one or more unique 'graphTraversal' objects.
      * 
@@ -178,7 +176,7 @@ public class Result {
     @JsonProperty("graphTraversals")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of one or more unique 'graphTraversal' objects.")
-    private Set<GraphTraversal> graphTraversals = new LinkedHashSet<GraphTraversal>();
+    private Set<GraphTraversal> graphTraversals = null;
     /**
      * A set of locations relevant to this result.
      * 
@@ -186,7 +184,7 @@ public class Result {
     @JsonProperty("relatedLocations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("A set of locations relevant to this result.")
-    private Set<Location> relatedLocations = new LinkedHashSet<Location>();
+    private Set<Location> relatedLocations = null;
     /**
      * A set of suppressions relevant to this result.
      * 
@@ -194,7 +192,7 @@ public class Result {
     @JsonProperty("suppressions")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("A set of suppressions relevant to this result.")
-    private Set<Suppression> suppressions = new LinkedHashSet<Suppression>();
+    private Set<Suppression> suppressions = null;
     /**
      * The state of a result relative to a baseline of a previous run.
      * 
@@ -216,7 +214,7 @@ public class Result {
     @JsonProperty("attachments")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("A set of artifacts relevant to the result.")
-    private Set<Attachment> attachments = new LinkedHashSet<Attachment>();
+    private Set<Attachment> attachments = null;
     /**
      * An absolute URI at which the result can be viewed.
      * 
@@ -231,7 +229,7 @@ public class Result {
     @JsonProperty("workItemUris")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("The URIs of the work items associated with this result.")
-    private Set<URI> workItemUris = new LinkedHashSet<URI>();
+    private Set<URI> workItemUris = null;
     /**
      * Contains information about how and when a result was detected.
      * 
@@ -246,7 +244,7 @@ public class Result {
     @JsonProperty("fixes")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.")
-    private Set<Fix> fixes = new LinkedHashSet<Fix>();
+    private Set<Fix> fixes = null;
     /**
      * An array of references to taxonomy reporting descriptors that are applicable to the result.
      * 
@@ -254,7 +252,7 @@ public class Result {
     @JsonProperty("taxa")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of references to taxonomy reporting descriptors that are applicable to the result.")
-    private Set<ReportingDescriptorReference> taxa = new LinkedHashSet<ReportingDescriptorReference>();
+    private Set<ReportingDescriptorReference> taxa = null;
     /**
      * Describes an HTTP request.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ResultProvenance.java
+++ b/src/main/java/com/contrastsecurity/sarif/ResultProvenance.java
@@ -2,7 +2,6 @@
 package com.contrastsecurity.sarif;
 
 import java.util.Date;
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -15,7 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Contains information about how and when a result was detected.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "firstDetectionTimeUtc",
     "lastDetectionTimeUtc",
@@ -69,7 +68,7 @@ public class ResultProvenance {
     @JsonProperty("conversionSources")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.")
-    private Set<PhysicalLocation> conversionSources = new LinkedHashSet<PhysicalLocation>();
+    private Set<PhysicalLocation> conversionSources = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/Run.java
+++ b/src/main/java/com/contrastsecurity/sarif/Run.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -21,7 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Describes a single run of an analysis tool, and contains the reported output of that run.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "tool",
     "invocations",
@@ -68,7 +67,7 @@ public class Run {
      */
     @JsonProperty("invocations")
     @JsonPropertyDescription("Describes the invocation of the analysis tool.")
-    private List<Invocation> invocations = new ArrayList<Invocation>();
+    private List<Invocation> invocations = null;
     /**
      * Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.
      * 
@@ -90,7 +89,7 @@ public class Run {
     @JsonProperty("versionControlProvenance")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Specifies the revision in version control of the artifacts that were scanned.")
-    private Set<VersionControlDetails> versionControlProvenance = new LinkedHashSet<VersionControlDetails>();
+    private Set<VersionControlDetails> versionControlProvenance = null;
     /**
      * The artifact location specified by each uriBaseId symbol on the machine where the tool originally ran.
      * 
@@ -105,7 +104,7 @@ public class Run {
     @JsonProperty("artifacts")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of artifact objects relevant to the run.")
-    private Set<Artifact> artifacts = new LinkedHashSet<Artifact>();
+    private Set<Artifact> artifacts = null;
     /**
      * An array of logical locations such as namespaces, types or functions.
      * 
@@ -113,7 +112,7 @@ public class Run {
     @JsonProperty("logicalLocations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of logical locations such as namespaces, types or functions.")
-    private Set<LogicalLocation> logicalLocations = new LinkedHashSet<LogicalLocation>();
+    private Set<LogicalLocation> logicalLocations = null;
     /**
      * An array of zero or more unique graph objects associated with the run.
      * 
@@ -121,14 +120,14 @@ public class Run {
     @JsonProperty("graphs")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of zero or more unique graph objects associated with the run.")
-    private Set<Graph> graphs = new LinkedHashSet<Graph>();
+    private Set<Graph> graphs = null;
     /**
      * The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.
      * 
      */
     @JsonProperty("results")
     @JsonPropertyDescription("The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.")
-    private List<Result> results = new ArrayList<Result>();
+    private List<Result> results = null;
     /**
      * Information that describes a run's identity and role within an engineering system process.
      * 
@@ -143,7 +142,7 @@ public class Run {
     @JsonProperty("runAggregates")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Automation details that describe the aggregate of runs to which this run belongs.")
-    private Set<RunAutomationDetails> runAggregates = new LinkedHashSet<RunAutomationDetails>();
+    private Set<RunAutomationDetails> runAggregates = null;
     /**
      * The 'guid' property of a previous SARIF 'run' that comprises the baseline that was used to compute result 'baselineState' properties for the run.
      * 
@@ -158,7 +157,7 @@ public class Run {
     @JsonProperty("redactionTokens")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of strings used to replace sensitive information in a redaction-aware property.")
-    private Set<String> redactionTokens = new LinkedHashSet<String>();
+    private Set<String> redactionTokens = null;
     /**
      * Specifies the default encoding for any artifact object that refers to a text file.
      * 
@@ -202,7 +201,7 @@ public class Run {
     @JsonProperty("threadFlowLocations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of threadFlowLocation objects cached at run level.")
-    private Set<ThreadFlowLocation> threadFlowLocations = new LinkedHashSet<ThreadFlowLocation>();
+    private Set<ThreadFlowLocation> threadFlowLocations = null;
     /**
      * An array of toolComponent objects relevant to a taxonomy in which results are categorized.
      * 
@@ -210,14 +209,14 @@ public class Run {
     @JsonProperty("taxonomies")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of toolComponent objects relevant to a taxonomy in which results are categorized.")
-    private Set<ToolComponent> taxonomies = new LinkedHashSet<ToolComponent>();
+    private Set<ToolComponent> taxonomies = null;
     /**
      * Addresses associated with this run instance, if any.
      * 
      */
     @JsonProperty("addresses")
     @JsonPropertyDescription("Addresses associated with this run instance, if any.")
-    private List<Address> addresses = new ArrayList<Address>();
+    private List<Address> addresses = null;
     /**
      * The set of available translations of the localized data provided by the tool.
      * 
@@ -225,7 +224,7 @@ public class Run {
     @JsonProperty("translations")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("The set of available translations of the localized data provided by the tool.")
-    private Set<ToolComponent> translations = new LinkedHashSet<ToolComponent>();
+    private Set<ToolComponent> translations = null;
     /**
      * Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's default severities) and invocation.configurationOverrides (severities established at run-time from the command line).
      * 
@@ -233,7 +232,7 @@ public class Run {
     @JsonProperty("policies")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's default severities) and invocation.configurationOverrides (severities established at run-time from the command line).")
-    private Set<ToolComponent> policies = new LinkedHashSet<ToolComponent>();
+    private Set<ToolComponent> policies = null;
     /**
      * An array of request objects cached at run level.
      * 
@@ -241,7 +240,7 @@ public class Run {
     @JsonProperty("webRequests")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of request objects cached at run level.")
-    private Set<WebRequest> webRequests = new LinkedHashSet<WebRequest>();
+    private Set<WebRequest> webRequests = null;
     /**
      * An array of response objects cached at run level.
      * 
@@ -249,7 +248,7 @@ public class Run {
     @JsonProperty("webResponses")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of response objects cached at run level.")
-    private Set<WebResponse> webResponses = new LinkedHashSet<WebResponse>();
+    private Set<WebResponse> webResponses = null;
     /**
      * Defines locations of special significance to SARIF consumers.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/RunAutomationDetails.java
+++ b/src/main/java/com/contrastsecurity/sarif/RunAutomationDetails.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Information that describes a run's identity and role within an engineering system process.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "description",
     "id",

--- a/src/main/java/com/contrastsecurity/sarif/SarifSchema210.java
+++ b/src/main/java/com/contrastsecurity/sarif/SarifSchema210.java
@@ -2,9 +2,7 @@
 package com.contrastsecurity.sarif;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -23,7 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema: a standard format for the output of static analysis tools.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "$schema",
     "version",
@@ -55,7 +53,7 @@ public class SarifSchema210 {
      */
     @JsonProperty("runs")
     @JsonPropertyDescription("The set of runs contained in this log file.")
-    private List<Run> runs = new ArrayList<Run>();
+    private List<Run> runs = null;
     /**
      * References to external property files that share data between runs.
      * 
@@ -63,7 +61,7 @@ public class SarifSchema210 {
     @JsonProperty("inlineExternalProperties")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("References to external property files that share data between runs.")
-    private Set<ExternalProperties> inlineExternalProperties = new LinkedHashSet<ExternalProperties>();
+    private Set<ExternalProperties> inlineExternalProperties = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/SpecialLocations.java
+++ b/src/main/java/com/contrastsecurity/sarif/SpecialLocations.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Defines locations of special significance to SARIF consumers.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "displayBase",
     "properties"

--- a/src/main/java/com/contrastsecurity/sarif/Stack.java
+++ b/src/main/java/com/contrastsecurity/sarif/Stack.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A call stack that is relevant to a result.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "message",
     "frames",
@@ -35,7 +34,7 @@ public class Stack {
      */
     @JsonProperty("frames")
     @JsonPropertyDescription("An array of stack frames that represents a sequence of calls, rendered in reverse chronological order, that comprise the call stack.")
-    private List<StackFrame> frames = new ArrayList<StackFrame>();
+    private List<StackFrame> frames = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/StackFrame.java
+++ b/src/main/java/com/contrastsecurity/sarif/StackFrame.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A function call within a stack trace.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "location",
     "module",
@@ -50,7 +49,7 @@ public class StackFrame {
      */
     @JsonProperty("parameters")
     @JsonPropertyDescription("The parameters of the call that is executing.")
-    private List<String> parameters = new ArrayList<String>();
+    private List<String> parameters = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/State.java
+++ b/src/main/java/com/contrastsecurity/sarif/State.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * A dictionary, each of whose keys specifies a variable or expression, the associated value of which represents the variable or expression value. For an annotation of kind 'continuation', for example, this dictionary might hold the current assumed values of a set of global variables.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
 
 })

--- a/src/main/java/com/contrastsecurity/sarif/Suppression.java
+++ b/src/main/java/com/contrastsecurity/sarif/Suppression.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * A suppression that is relevant to a result.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "guid",
     "kind",

--- a/src/main/java/com/contrastsecurity/sarif/ThreadFlow.java
+++ b/src/main/java/com/contrastsecurity/sarif/ThreadFlow.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.ArrayList;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Describes a sequence of code locations that specify a path through a single thread of execution such as an operating system or fiber.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "id",
     "message",
@@ -59,7 +58,7 @@ public class ThreadFlow {
      */
     @JsonProperty("locations")
     @JsonPropertyDescription("A temporally ordered array of 'threadFlowLocation' objects, each of which describes a location visited by the tool while producing the result.")
-    private List<ThreadFlowLocation> locations = new ArrayList<ThreadFlowLocation>();
+    private List<ThreadFlowLocation> locations = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ThreadFlowLocation.java
+++ b/src/main/java/com/contrastsecurity/sarif/ThreadFlowLocation.java
@@ -3,7 +3,6 @@ package com.contrastsecurity.sarif;
 
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -19,7 +18,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * A location visited by an analysis tool while simulating or monitoring the execution of a program.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "index",
     "location",
@@ -66,7 +65,7 @@ public class ThreadFlowLocation {
     @JsonProperty("kinds")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire', 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger', 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.")
-    private Set<String> kinds = new LinkedHashSet<String>();
+    private Set<String> kinds = null;
     /**
      * An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.
      * 
@@ -74,7 +73,7 @@ public class ThreadFlowLocation {
     @JsonProperty("taxa")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.")
-    private Set<ReportingDescriptorReference> taxa = new LinkedHashSet<ReportingDescriptorReference>();
+    private Set<ReportingDescriptorReference> taxa = null;
     /**
      * The name of the module that contains the code that is executing.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/Tool.java
+++ b/src/main/java/com/contrastsecurity/sarif/Tool.java
@@ -1,7 +1,6 @@
 
 package com.contrastsecurity.sarif;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,7 +13,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * The analysis tool that was run.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "driver",
     "extensions",
@@ -37,7 +36,7 @@ public class Tool {
     @JsonProperty("extensions")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("Tool extensions that contributed to or reconfigured the analysis tool that was run.")
-    private Set<ToolComponent> extensions = new LinkedHashSet<ToolComponent>();
+    private Set<ToolComponent> extensions = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ToolComponent.java
+++ b/src/main/java/com/contrastsecurity/sarif/ToolComponent.java
@@ -2,7 +2,6 @@
 package com.contrastsecurity.sarif;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -18,7 +17,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * A component, such as a plug-in or the driver, of the analysis tool that was run.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "guid",
     "name",
@@ -164,7 +163,7 @@ public class ToolComponent {
     @JsonProperty("notifications")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime execution of the tool component.")
-    private Set<ReportingDescriptor> notifications = new LinkedHashSet<ReportingDescriptor>();
+    private Set<ReportingDescriptor> notifications = null;
     /**
      * An array of reportingDescriptor objects relevant to the analysis performed by the tool component.
      * 
@@ -172,7 +171,7 @@ public class ToolComponent {
     @JsonProperty("rules")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of reportingDescriptor objects relevant to the analysis performed by the tool component.")
-    private Set<ReportingDescriptor> rules = new LinkedHashSet<ReportingDescriptor>();
+    private Set<ReportingDescriptor> rules = null;
     /**
      * An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.
      * 
@@ -180,14 +179,14 @@ public class ToolComponent {
     @JsonProperty("taxa")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.")
-    private Set<ReportingDescriptor> taxa = new LinkedHashSet<ReportingDescriptor>();
+    private Set<ReportingDescriptor> taxa = null;
     /**
      * An array of the artifactLocation objects associated with the tool component.
      * 
      */
     @JsonProperty("locations")
     @JsonPropertyDescription("An array of the artifactLocation objects associated with the tool component.")
-    private List<ArtifactLocation> locations = new ArrayList<ArtifactLocation>();
+    private List<ArtifactLocation> locations = null;
     /**
      * The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).
      * 
@@ -245,7 +244,7 @@ public class ToolComponent {
     @JsonProperty("supportedTaxonomies")
     @JsonDeserialize(as = java.util.LinkedHashSet.class)
     @JsonPropertyDescription("An array of toolComponentReference objects to declare the taxonomies supported by the tool component.")
-    private Set<ToolComponentReference> supportedTaxonomies = new LinkedHashSet<ToolComponentReference>();
+    private Set<ToolComponentReference> supportedTaxonomies = null;
     /**
      * Key/value pairs that provide additional information about the object.
      * 

--- a/src/main/java/com/contrastsecurity/sarif/ToolComponentReference.java
+++ b/src/main/java/com/contrastsecurity/sarif/ToolComponentReference.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Identifies a particular toolComponent object, either the driver or an extension.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "name",
     "index",

--- a/src/main/java/com/contrastsecurity/sarif/TranslationMetadata.java
+++ b/src/main/java/com/contrastsecurity/sarif/TranslationMetadata.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Provides additional metadata related to translation.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "name",
     "fullName",

--- a/src/main/java/com/contrastsecurity/sarif/VersionControlDetails.java
+++ b/src/main/java/com/contrastsecurity/sarif/VersionControlDetails.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Specifies the information necessary to retrieve a desired revision from a version control system.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "repositoryUri",
     "revisionId",

--- a/src/main/java/com/contrastsecurity/sarif/WebRequest.java
+++ b/src/main/java/com/contrastsecurity/sarif/WebRequest.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Describes an HTTP request.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "index",
     "protocol",

--- a/src/main/java/com/contrastsecurity/sarif/WebResponse.java
+++ b/src/main/java/com/contrastsecurity/sarif/WebResponse.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Describes the response to an HTTP request.
  * 
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({
     "index",
     "protocol",

--- a/src/test/java/com/contrastsecurity/sarif/SerializationTests.java
+++ b/src/test/java/com/contrastsecurity/sarif/SerializationTests.java
@@ -1,0 +1,29 @@
+package com.contrastsecurity.sarif;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+public class SerializationTests {
+  @Test
+  void it_serializes_without_junk() throws IOException {
+   Result result = new Result()
+       .withMessage(new Message().withText("hi"))
+       .withLevel(Result.Level.ERROR);
+
+    StringWriter writer = new StringWriter();
+    ObjectMapper mapper = new ObjectMapper();
+    JsonGenerator generator = mapper.writerWithDefaultPrettyPrinter().createGenerator(writer);
+
+    generator.writeObject(result);
+    JsonNode actual =  new ObjectMapper().readTree(writer.toString());
+    JsonNode expected = new ObjectMapper().readTree("{\"level\" : \"error\", \"message\" : { \"text\" : \"hi\" } }");
+
+    assertThat(actual).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
the only real changes here are in the pom.xml file.  The rest of the files are generated from jsonschema2pojo.  In the sarif standard, anything not present is assumed to have the default value by the consumer.  Our serializer was filling in all the defaults and making for some very noisy sarif.  These changes remove and field with a default value from serialization which shortens the sarif considerably and makes it a little more human readable.